### PR TITLE
fixed defaults for delaying parameters computation

### DIFF
--- a/release/ov7670/edge-line-sensor-ov7670.default
+++ b/release/ov7670/edge-line-sensor-ov7670.default
@@ -1,4 +1,4 @@
 #line-sensor-ov7670 default opts
 VIDEO_PORT=0
 VIDEO_PATH=/dev/video$VIDEO_PORT
-DEFAULT_OPS="--v4l2-path=$VIDEO_PATH"
+DEFAULT_OPS='--v4l2-path=$VIDEO_PATH'

--- a/release/ov7670/jpeg-encoder-ov7670.default
+++ b/release/ov7670/jpeg-encoder-ov7670.default
@@ -1,4 +1,4 @@
 #mjpg-encoder-ov7670 default opts
 VIDEO_PORT=0
 VIDEO_PATH=/dev/video$VIDEO_PORT
-DEFAULT_OPS="--v4l2-path=$VIDEO_PATH"
+DEFAULT_OPS='--v4l2-path=$VIDEO_PATH'

--- a/release/ov7670/line-sensor-ov7670.default
+++ b/release/ov7670/line-sensor-ov7670.default
@@ -1,4 +1,4 @@
 #line-sensor-ov7670 default opts
 VIDEO_PORT=0
 VIDEO_PATH=/dev/video$VIDEO_PORT
-DEFAULT_OPS="--v4l2-path=$VIDEO_PATH"
+DEFAULT_OPS='--v4l2-path=$VIDEO_PATH'

--- a/release/ov7670/motion-sensor-ov7670.default
+++ b/release/ov7670/motion-sensor-ov7670.default
@@ -1,4 +1,4 @@
 #motion-sensor-ov7670 default opts
 VIDEO_PORT=0
 VIDEO_PATH=/dev/video$VIDEO_PORT
-DEFAULT_OPS="--v4l2-path=$VIDEO_PATH"
+DEFAULT_OPS='--v4l2-path=$VIDEO_PATH'

--- a/release/ov7670/mxn-sensor-ov7670.default
+++ b/release/ov7670/mxn-sensor-ov7670.default
@@ -1,4 +1,4 @@
 #Linetracer default opts
 VIDEO_PORT=0
 VIDEO_PATH=/dev/video$VIDEO_PORT
-DEFAULT_OPS="--v4l2-path=$VIDEO_PATH --mxn-width-m=3 --mxn-height-n=3"
+DEFAULT_OPS='--v4l2-path=$VIDEO_PATH --mxn-width-m=3 --mxn-height-n=3'

--- a/release/ov7670/object-sensor-ov7670.default
+++ b/release/ov7670/object-sensor-ov7670.default
@@ -1,4 +1,4 @@
 #object-sensor-ov7670 default opts
 VIDEO_PORT=0
 VIDEO_PATH=/dev/video$VIDEO_PORT
-DEFAULT_OPS="--v4l2-path=$VIDEO_PATH"
+DEFAULT_OPS='--v4l2-path=$VIDEO_PATH'


### PR DESCRIPTION
ex.:
defaults is
"VIDEO_PORT=0
VIDEO_PATH=/dev/video$VIDEO_PORT
DEFAULT_OPS='--v4l2-path=$VIDEO_PATH'"
let we redefine VIDEO_PORT=1 on "media-sensor start"
...
VIDEO_PORT=1
...
eval "DEFAULT_OPS=$DEFAULT_OPS" #allows to recompute defaults params
